### PR TITLE
Update to github.com/shirou/gopsutil v2.20.5 (#7641)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/Microsoft/ApplicationInsights-Go v0.4.2
 	github.com/Microsoft/go-winio v0.4.9 // indirect
 	github.com/Shopify/sarama v1.24.1
-	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
+	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/aerospike/aerospike-client-go v1.27.0
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
@@ -109,7 +109,7 @@ require (
 	github.com/safchain/ethtool v0.0.0-20200218184317-f459e2d13664
 	github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
-	github.com/shirou/gopsutil v2.20.2+incompatible
+	github.com/shirou/gopsutil v2.20.5+incompatible
 	github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/soniah/gosnmp v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec h1:6ncX5ko6B9L
 github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shirou/gopsutil v2.20.2+incompatible h1:ucK79BhBpgqQxPASyS2cu9HX8cfDVljBN1WWFvbNvgY=
-github.com/shirou/gopsutil v2.20.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
+github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114 h1:Pm6R878vxWWWR+Sa3ppsLce/Zq+JNTs6aVvRu13jv9A=
 github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=

--- a/plugins/inputs/procstat/native_finder_notwindows.go
+++ b/plugins/inputs/procstat/native_finder_notwindows.go
@@ -32,28 +32,3 @@ func (pg *NativeFinder) Pattern(pattern string) ([]PID, error) {
 	}
 	return pids, err
 }
-
-//FullPattern matches on the command line when the process was executed
-func (pg *NativeFinder) FullPattern(pattern string) ([]PID, error) {
-	var pids []PID
-	regxPattern, err := regexp.Compile(pattern)
-	if err != nil {
-		return pids, err
-	}
-	procs, err := process.Processes()
-	if err != nil {
-		return pids, err
-	}
-	for _, p := range procs {
-		cmd, err := p.Cmdline()
-		if err != nil {
-			//skip, this can be caused by the pid no longer existing
-			//or you having no permissions to access it
-			continue
-		}
-		if regxPattern.MatchString(cmd) {
-			pids = append(pids, PID(p.Pid))
-		}
-	}
-	return pids, err
-}

--- a/plugins/inputs/procstat/native_finder_test.go
+++ b/plugins/inputs/procstat/native_finder_test.go
@@ -1,0 +1,29 @@
+package procstat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkPattern(b *testing.B) {
+	f, err := NewNativeFinder()
+	require.NoError(b, err)
+	for n := 0; n < b.N; n++ {
+		_, err := f.Pattern(".*")
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkFullPattern(b *testing.B) {
+	f, err := NewNativeFinder()
+	require.NoError(b, err)
+	for n := 0; n < b.N; n++ {
+		_, err := f.FullPattern(".*")
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/plugins/inputs/procstat/native_finder_windows.go
+++ b/plugins/inputs/procstat/native_finder_windows.go
@@ -1,27 +1,12 @@
 package procstat
 
 import (
-	"context"
-	"fmt"
 	"regexp"
-	"time"
 
-	"github.com/StackExchange/wmi"
 	"github.com/shirou/gopsutil/process"
 )
 
-//Timeout is the timeout used when making wmi calls
-var Timeout = 5 * time.Second
-
-type queryType string
-
-const (
-	like     = queryType("LIKE")
-	equals   = queryType("=")
-	notEqual = queryType("!=")
-)
-
-//Pattern matches on the process name
+// Pattern matches on the process name
 func (pg *NativeFinder) Pattern(pattern string) ([]PID, error) {
 	var pids []PID
 	regxPattern, err := regexp.Compile(pattern)
@@ -44,48 +29,4 @@ func (pg *NativeFinder) Pattern(pattern string) ([]PID, error) {
 		}
 	}
 	return pids, err
-}
-
-//FullPattern matches the cmdLine on windows and will find a pattern using a WMI like query
-func (pg *NativeFinder) FullPattern(pattern string) ([]PID, error) {
-	var pids []PID
-	procs, err := getWin32ProcsByVariable("CommandLine", like, pattern, Timeout)
-	if err != nil {
-		return pids, err
-	}
-	for _, p := range procs {
-		pids = append(pids, PID(p.ProcessID))
-	}
-	return pids, nil
-}
-
-//GetWin32ProcsByVariable allows you to query any variable with a like query
-func getWin32ProcsByVariable(variable string, qType queryType, value string, timeout time.Duration) ([]process.Win32_Process, error) {
-	var dst []process.Win32_Process
-	var query string
-	// should look like "WHERE CommandLine LIKE "procstat"
-	query = fmt.Sprintf("WHERE %s %s %q", variable, qType, value)
-	q := wmi.CreateQuery(&dst, query)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	err := WMIQueryWithContext(ctx, q, &dst)
-	if err != nil {
-		return []process.Win32_Process{}, fmt.Errorf("could not get win32Proc: %s", err)
-	}
-	return dst, nil
-}
-
-// WMIQueryWithContext - wraps wmi.Query with a timed-out context to avoid hanging
-func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, connectServerArgs ...interface{}) error {
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- wmi.Query(query, dst, connectServerArgs...)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-errChan:
-		return err
-	}
 }


### PR DESCRIPTION
Cherry pick procstat windows 2016 memory leak fix.
See: https://github.com/influxdata/telegraf/issues/6807
And: https://github.com/influxdata/telegraf/commit/894841a723e1db115f2f59c1aeb9ea77dc8ba6e3