### PR TITLE
Add common package from gopsutil upstream

### DIFF
--- a/patches/gopsutil/v3/common/env.go
+++ b/patches/gopsutil/v3/common/env.go
@@ -1,0 +1,23 @@
+package common
+
+type EnvKeyType string
+
+// EnvKey is a context key that can be used to set programmatically the environment
+// gopsutil relies on to perform calls against the OS.
+// Example of use:
+//
+//	ctx := context.WithValue(context.Background(), common.EnvKey, EnvMap{common.HostProcEnvKey: "/myproc"})
+//	avg, err := load.AvgWithContext(ctx)
+var EnvKey = EnvKeyType("env")
+
+const (
+	HostProcEnvKey EnvKeyType = "HOST_PROC"
+	HostSysEnvKey  EnvKeyType = "HOST_SYS"
+	HostEtcEnvKey  EnvKeyType = "HOST_ETC"
+	HostVarEnvKey  EnvKeyType = "HOST_VAR"
+	HostRunEnvKey  EnvKeyType = "HOST_RUN"
+	HostDevEnvKey  EnvKeyType = "HOST_DEV"
+	HostRootEnvKey EnvKeyType = "HOST_ROOT"
+)
+
+type EnvMap map[EnvKeyType]string


### PR DESCRIPTION
This PR is to add [common package](https://github.com/shirou/gopsutil/tree/master/common) from gopsutil upstream. We need this in order to upgrade OTEL version to v0.84.0 since there was a [recent change](https://github.com/open-telemetry/opentelemetry-collector/blame/main/service/internal/proctelemetry/process_telemetry.go#L14) to include this package. 

We can't use gopsutil upstream since we made our change to fix the dimension name change for LVM volumes in disk input plugin. More details can be read [here](https://github.com/aws/telegraf/pull/5) 