### PR TITLE
Fix memory_swap Metric and Add Config Option in procstat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/influxdata/telegraf
 
-go 1.20
+go 1.21
+
+toolchain go1.22.5
 
 require (
 	cloud.google.com/go/bigquery v1.55.0

--- a/plugins/inputs/procstat/memmap.go
+++ b/plugins/inputs/procstat/memmap.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package procstat
+
+func collectMemmap(proc Process, prefix string, fields map[string]any) {
+	memMapStats, err := proc.MemoryMaps(true)
+	if err == nil && len(*memMapStats) == 1 {
+		memMap := (*memMapStats)[0]
+		fields[prefix+"memory_size"] = memMap.Size
+		fields[prefix+"memory_pss"] = memMap.Pss
+		fields[prefix+"memory_shared_clean"] = memMap.SharedClean
+		fields[prefix+"memory_shared_dirty"] = memMap.SharedDirty
+		fields[prefix+"memory_private_clean"] = memMap.PrivateClean
+		fields[prefix+"memory_private_dirty"] = memMap.PrivateDirty
+		fields[prefix+"memory_referenced"] = memMap.Referenced
+		fields[prefix+"memory_anonymous"] = memMap.Anonymous
+		fields[prefix+"memory_swap"] = memMap.Swap
+	}
+}

--- a/plugins/inputs/procstat/memmap_notlinux.go
+++ b/plugins/inputs/procstat/memmap_notlinux.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package procstat
+
+func collectMemmap(Process, string, map[string]any) {}

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -16,6 +16,7 @@ type Process interface {
 	IOCounters() (*process.IOCountersStat, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
 	Name() (string, error)
+	MemoryMaps(bool) (*[]process.MemoryMapsStat, error)
 	Cmdline() (string, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
 	NumFDs() (int32, error)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -283,11 +283,9 @@ func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator, t time.Time
 	if err == nil {
 		fields[prefix+"memory_rss"] = mem.RSS
 		fields[prefix+"memory_vms"] = mem.VMS
-		fields[prefix+"memory_swap"] = mem.Swap
-		fields[prefix+"memory_data"] = mem.Data
-		fields[prefix+"memory_stack"] = mem.Stack
-		fields[prefix+"memory_locked"] = mem.Locked
 	}
+
+	collectMemmap(proc, prefix, fields)
 
 	memPerc, err := proc.MemoryPercent()
 	if err == nil {

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -131,6 +131,10 @@ func (p *testProc) MemoryInfo() (*process.MemoryInfoStat, error) {
 	return &process.MemoryInfoStat{}, nil
 }
 
+func (p *testProc) MemoryMaps(bool) (*[]process.MemoryMapsStat, error) {
+	return &[]process.MemoryMapsStat{}, nil
+}
+
 func (p *testProc) Name() (string, error) {
 	return "test_proc", nil
 }


### PR DESCRIPTION
### Required for all PRs:

## This PR pulls changes from two pull requests:

1. Memory Swap Metric Always 0: Fixes the issue where the memory_swap metric always reports as 0. [PR #13779](https://github.com/influxdata/telegraf/pull/13779)
2. Enable memory_swap via Configuration: Adds the ability to enable the memory_swap metric in procstat only when explicitly defined in the TOML configuration. [Issue #15295](https://github.com/influxdata/telegraf/issues/15295) (Note: Only the memory_swap metric is implemented, other metrics such as CPU are not included).

## Details:
The proc.MemoryInfo() function in Telegraf claims to collect RSS, VMS, swap, data, stack, and locked memory information. However, it was reading only from /proc/$PID/statm, which provides RSS and VMS but not swap information. This PR introduces a fix by reading swap memory details from /proc/$PID/smaps and allows the memory_swap metric to be emitted when the properties = ["mmap"] configuration is present under inputs.procstat.

# Testing 
Testing was done using this toml configuration 
```
[agent]
  collection_jitter = "0s"
  debug = false
  flush_interval = "1s"
  flush_jitter = "0s"
  hostname = ""
  interval = "60s"
  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
  logtarget = "lumberjack"
  metric_batch_size = 1000
  metric_buffer_limit = 10000
  omit_hostname = false
  precision = ""
  quiet = false
  round_interval = false

[inputs]

  [[inputs.procstat]]
    alias = "793254176"
    fieldpass = ["memory_swap"]
    pattern = "amazon-cloudwatch-agent"
    pid_finder = "native"
    properties = ["mmap"] // this enables memory_swap metric
    tagexclude = ["user", "result"]

[outputs]

  [[outputs.cloudwatch]]
```


## Image of toml configuration of the agent
![Screenshot 2024-09-25 at 2 11 39 PM](https://github.com/user-attachments/assets/1df96c4a-aac1-45aa-b6a2-e27739c894d0)


Using this configuiration we made sure that swap memory was configured on the instance so we ran these commands to configure 20GB of swap memory:
```
sudo swapoff /swapfile
sudo fallocate -l 20G /swapfile //I set it to 20GB but you can do something less or more
sudo chmod 600 /swapfile
sudo mkswap /swapfile
sudo swapon /swapfile
swapon --show //verifying swap
```

The stress test that was run in order to use up all the memory was 
`echo {1..10000000000} &`

How this works is that the Shell, before giving the command to the kernel, Expands all the regular expressions and short-hands. The expanded command is temporarily stored in RAM, which fills up way more than  30GB of RAM leading to usage of swap memory.



## Image of htop console (displays 100% ram usage and ~70% swap memory usage)
<img width="1631" alt="Screenshot 2024-09-25 at 4 41 35 PM" src="https://github.com/user-attachments/assets/76ef27c1-ef7f-4744-96d5-102639f060b1">


Running `sudo cat /proc/<amazon-cloudwatch-agent-pid>/smaps | grep swap` gives you the swap memory used by the agent process 


## Swap memory used by the agent
<img width="1449" alt="Screenshot 2024-09-25 at 4 41 46 PM" src="https://github.com/user-attachments/assets/6f745e84-2f46-4348-8301-2599b57ec2da">

## AWS Console displaying non-zero memory_swap metric
![image](https://github.com/user-attachments/assets/a0d48fef-2ad6-40a1-9102-b12fda3f4d24)

Pulled changes from these commits: 
https://github.com/influxdata/telegraf/pull/13779
https://github.com/influxdata/telegraf/issues/15295


Fixed these issues: 
https://github.com/influxdata/telegraf/issues/8557
https://github.com/influxdata/telegraf/issues/15295



